### PR TITLE
[DBUS-4] Make docs refer to JIRA issue tracker instead of githubs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/elbenfreund/hamster-dbus/issues.
+Report bugs at https://projecthamster.atlassian.net/projects/DBUS/issues/.
 
 If you are reporting a bug, please include:
 
@@ -24,26 +24,26 @@ If you are reporting a bug, please include:
 Fix Bugs
 ~~~~~~~~
 
-Look through the GitHub issues for bugs. Anything tagged with "bug"
+Look through the issues for bugs. Anything with the type "bug"
 is open to whoever wants to implement it.
 
 Implement Features
 ~~~~~~~~~~~~~~~~~~
 
-Look through the GitHub issues for features. Anything tagged with "feature"
+Look through the issues for features. Anything typed as a "story" or "task"
 is open to whoever wants to implement it.
 
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-hamster-dbus could always use more documentation, whether as part of the
-official hamster-dbus docs, in docstrings, or even on the web in blog posts,
-articles, and such.
+``hamster-dbus`` could always use more documentation, whether as part of the
+official ``hamster-dbus`` docs, in docstrings, or even on the web in blog
+posts, articles, and such.
 
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/elbenfreund/hamster-dbus/issues.
+The best way to send feedback is to file an issue at https://projecthamster.atlassian.net/projects/DBUS/issues/.
 
 If you are proposing a feature:
 

--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,11 @@ launches a separate session bus in a new process that our "objects to be
 tested" get hooked into.  While this works most of the time there are two
 practical issues here (besides not being proper unit tests):
 
-1. You may see an error like this when running the test suite: ..
+1. You may see an error like this when running the test suite::
 
     [xcb] Unknown sequence number while processing queue
-    [xcb] Most likely this is a multi-threaded client and XInitThreads has not
-    been called
+    [xcb] Most likely this is a multi-threaded client and XInitThreads has not \
+        been called
     [xcb] Aborting, sorry about that.
 
     Whilst we do not really understand whats going on this is most likely due
@@ -44,7 +44,7 @@ test setup we would be most grateful! Until then we will not be able to
 automatically run the test suite on a CI server which greatly limits our QA :(
 
 To run the test suite locally, just execute the following within your
-virtualenv (after ``make develop``): ..
+virtualenv (after ``make develop``)::
 
     make test
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents:
    authors
    packaging
    history
+   modules
 
 Indices and tables
 ==================


### PR DESCRIPTION
Closes [DBUS-4](https://projecthamster.atlassian.net/browse/DBUS-4)