### PR TITLE
[DBUS-8] Provide dbus storage backend

### DIFF
--- a/hamster_dbus/storage.py
+++ b/hamster_dbus/storage.py
@@ -1,0 +1,594 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Eric Goller <eric.goller@ninjaduck.solutions>
+
+# This file is part of 'hamster-dbus'.
+#
+# 'hamster-dbus' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-dbus' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  'hamster-dbus'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This modules provides dbus backend conforming to the ``hamster_lib.storage`` API.
+
+Using this module allows clients direct all of their storage backend calls against
+a corresponding dbus service.
+"""
+
+# Whilst it usually preferred to inherit from ``hamster_lib.storage`` and just
+# implement the specific functional backend methods such an approach would have
+# meant that the mirroring dbus-service would have to export quite a few
+# 'private' manager methods.  For this reason we opted against it and instead
+# implement the relevant public manager methods 'from scratch'. The price for
+# that is that we duplicate errorhandling/sanity check code.
+
+
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+from gettext import gettext as _
+
+import dbus
+import hamster_lib.objects as lib_objects
+import hamster_lib.storage as lib_storage
+from future.utils import python_2_unicode_compatible
+from six import text_type
+
+import hamster_dbus.helpers as helpers
+
+
+@python_2_unicode_compatible
+class DBusStore(lib_storage.BaseStore):
+    """Store class for hamster-dbus storage backend."""
+
+    def __init__(self, config, bus=None):
+        """
+        Initialize a new instance.
+
+        Args:
+            config (dict): Dictionary containing config data.
+            bus (dbus.bus.BusConnection, optional): Connection to be used when
+            querying dbus objects. If ``None``, ``dbus.SessionBus()`` will be
+            used.
+
+        Returns:
+            DBusStore: DBusStore instance.
+        """
+        if bus is None:
+            bus = dbus.SessionBus()
+        self._bus = bus
+        self.config = config
+        self.categories = CategoryManager(self._bus)
+        self.activities = ActivityManager(self._bus)
+        self.tags = TagManager(self._bus)
+        self.facts = FactManager(self._bus)
+
+    def cleanup(self):
+        """Teardown chores."""
+        return None
+
+
+@python_2_unicode_compatible
+class CategoryManager(object):
+    """Class to handle categories."""
+
+    def __init__(self, bus):
+        """
+        Instantiate class.
+
+        Args:
+            bus (dbus.bus.BusConnection): Connection to query against.
+        """
+        bus_name = 'org.projecthamster.HamsterDBus'
+        object_path = '/org/projecthamster/HamsterDBus/CategoryManager'
+        interface_name = 'org.projecthamster.HamsterDBus.CategoryManager1'
+        dbus_object = bus.get_object(bus_name, object_path)
+        self._interface = dbus.Interface(dbus_object, interface_name)
+
+    def save(self, category):
+        """
+        Save a Category.
+
+        Args:
+            category (hamster_lib.Category): Category instance to be saved.
+
+        Returns:
+            hamster_lib.Category: Saved Category
+
+        Raises:
+            TypeError: If the ``category`` parameter is not a valid ``Category`` instance.
+        """
+        if not isinstance(category, lib_objects.Category):
+            message = _("You need to pass a hamster category")
+            raise TypeError(message)
+
+        dbus_category = helpers.hamster_to_dbus_category(category)
+        result = self._interface.Save(dbus_category)
+        return helpers.dbus_to_hamster_category(result)
+
+    def get_or_create(self, category):
+        """
+        Check if we already got a category with that name, if not create one.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+
+        Args:
+            category (hamster_lib.Category or None): The categories.
+
+        Returns:
+            hamster_lib.Category or None: The retrieved or created category. Either way,
+                the returned Category will contain all data from the backend, including
+                its primary key.
+
+        Raises:
+            TypeError: If ``category`` is not a ``lib_objects.Category`` instance.
+        """
+        if not isinstance(category, lib_objects.Category):
+            message = _("You need to pass a hamster category")
+            raise TypeError(message)
+
+        dbus_category = helpers.hamster_to_dbus_category(category)
+        result = self._interface.GetOrCreate(dbus_category)
+        return helpers.dbus_to_hamster_category(result)
+
+    def remove(self, category):
+        """
+        Remove a category.
+
+        Any ``Activity`` referencing the passed category will be set to
+        ``Activity().category=None``.
+
+        Args:
+            category (hamster_lib.Category): Category to be updated.
+
+        Returns:
+            None: If everything went ok.
+
+        Raises:
+            TypeError: If category passed is not an hamster_lib.Category instance.
+        """
+        if not isinstance(category, lib_objects.Category):
+            message = _("You need to pass a hamster category")
+            raise TypeError(message)
+
+        self._interface.Remove(category.pk)
+        return None
+
+    def get(self, pk):
+        """
+        Get an ``Category`` by its primary key.
+
+        Args:
+            pk (int): Primary key of the ``Category`` to be fetched.
+
+        Returns:
+            hamster_lib.Category: ``Category`` with given primary key.
+        """
+        result = self._interface.Get(int(pk))
+        return helpers.dbus_to_hamster_category(result)
+
+    def get_by_name(self, name):
+        """
+        Look up a category by its name.
+
+        Args:
+            name (str): Unique name of the ``Category`` to we want to fetch.
+
+        Returns:
+            hamster_lib.Category: ``Category`` with given name.
+        """
+        result = self._interface.GetByName(name)
+        return helpers.dbus_to_hamster_category(result)
+
+    def get_all(self):
+        """
+        Return a list of all categories.
+
+        Returns:
+            list: List of ``Categories``, ordered by ``lower(name)``.
+        """
+        result = self._interface.GetAll()
+        return [helpers.dbus_to_hamster_category(category) for category in result]
+
+
+@python_2_unicode_compatible
+class ActivityManager(object):
+    """Class to handle activities."""
+
+    def __init__(self, bus):
+        """
+        Instantiate class.
+
+        Args:
+            bus (dbus.bus.BusConnection): Connection to query against.
+        """
+        bus_name = 'org.projecthamster.HamsterDBus'
+        object_path = '/org/projecthamster/HamsterDBus/ActivityManager'
+        interface_name = 'org.projecthamster.HamsterDBus.ActivityManager1'
+        dbus_object = bus.get_object(bus_name, object_path)
+        self._interface = dbus.Interface(dbus_object, interface_name)
+
+    def save(self, activity):
+        """
+        Save an Activivty.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+        """
+        if not isinstance(activity, lib_objects.Activity):
+            message = _("You need to pass a ``hamster_lib.objects.Activity`` instance")
+            raise TypeError(message)
+
+        dbus_activity = helpers.hamster_to_dbus_activity(activity)
+        result = self._interface.Save(dbus_activity)
+        return helpers.dbus_to_hamster_activity(result)
+
+    def get_or_create(self, activity):
+        """
+        Convenience method to either get an activity matching the specs or create a new one.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+
+        Args:
+            activity (hamster_lib.Activity): The activity we want.
+
+        Returns:
+            hamster_lib.Activity: The retrieved or created activity
+
+        Raises:
+            TypeError: If ``activity`` is not a ``lib_objects.Activity`` instance.
+        """
+        if not isinstance(activity, lib_objects.Activity):
+            message = _("You need to pass a ``hamster_lib.objects.Activity`` instance")
+            raise TypeError(message)
+
+        dbus_activity = helpers.hamster_to_dbus_activity(activity)
+        result = self._interface.GetOrCreate(dbus_activity)
+        return helpers.dbus_to_hamster_activity(result)
+
+    def remove(self, activity):
+        """
+        Remove an ``Activity`` from the database.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+        """
+        if not isinstance(activity, lib_objects.Activity):
+            message = _("You need to pass a ``hamster_lib.objects.Activity`` instance")
+            raise TypeError(message)
+
+        dbus_activity = helpers.hamster_to_dbus_activity(activity)
+        self._interface.Remove(dbus_activity.pk)
+        return True
+
+    def get(self, pk):
+        """
+        Return an activity based on its primary key.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+        """
+        result = self._interface.Get(pk)
+        return helpers.dbus_to_hamster_activity(result)
+
+    def get_by_composite(self, name, category):
+        """
+        Lookup for unique 'name/category.name'-composite key.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+        """
+        if not (isinstance(category, lib_objects.Category) or (category is None)):
+            message = _("You need to pass a hamster_lib.objects.Category instance or None")
+            raise TypeError(message)
+
+        dbus_category = helpers.hamster_to_dbus_category(category)
+        name = text_type(name)
+        result = self._interface.GetByComposite(name, dbus_category)
+        return helpers.dbus_to_hamster_activity(result)
+
+    def get_all(self, category=False, search_term=''):
+        """
+        Return all matching activities.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+        """
+        if isinstance(category, lib_objects.Category):
+            category = category.pk
+        elif category is None:
+            category = -1
+        elif category is False:
+            category = -2
+        else:
+            message = _(
+                "'category' needs to be either a 'hamster_lib.objects.Category' instance,"
+                " 'False' or 'None'."
+            )
+            raise TypeError(message)
+
+        search_term = text_type(search_term)
+
+        result = self._interface.GetAll(category, search_term)
+        return [helpers.dbus_to_hamster_activity(activity) for activity in result]
+
+
+@python_2_unicode_compatible
+class TagManager(object):
+    """Class to handle tags."""
+
+    def __init__(self, bus):
+        """
+        Instantiate class.
+
+        Args:
+            bus (dbus.bus.BusConnection): Connection to query against.
+        """
+        bus_name = 'org.projecthamster.HamsterDBus'
+        object_path = '/org/projecthamster/HamsterDBus/TagManager'
+        interface_name = 'org.projecthamster.HamsterDBus.TagManager1'
+        dbus_object = bus.get_object(bus_name, object_path)
+        self._interface = dbus.Interface(dbus_object, interface_name)
+
+    def save(self, tag):
+        """
+        Save a tag.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+        """
+        if not isinstance(tag, lib_objects.Tag):
+            message = _("You need to pass a ``hamster_lib.objects.Tag`` instance")
+            raise TypeError(message)
+
+        dbus_tag = helpers.hamster_to_dbus_tag(tag)
+        result = self._interface.Save(dbus_tag)
+        return helpers.dbus_to_hamster_tag(result)
+
+    def get_or_create(self, tag):
+        """
+        Check if we already got a tag with that name, if not create one.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+
+        Args:
+            tag (hamster_lib.Tag): The tag we want.
+
+        Returns:
+            hamster_lib.Tag: The retrieved or created tag.
+
+        Raises:
+            TypeError: If ``tag`` is not a ``lib_objects.Tag`` instance.
+        """
+        if not isinstance(tag, lib_objects.Tag):
+            message = _("You need to pass a ``hamster_lib.objects.Tag`` instance")
+            raise TypeError(message)
+
+        dbus_tag = helpers.hamster_to_dbus_tag(tag)
+        result = self._interface.GetOrCreate(dbus_tag)
+        return helpers.dbus_to_hamster_tag(result)
+
+    def remove(self, tag):
+        """
+        Remove a tag.
+
+        Any ``Fact`` referencing the passed tag will have this tag removed.
+
+        Args:
+            tag (hamster_lib.Tag): Tag to be updated.
+
+        Returns:
+            None: If everything went ok.
+
+        Raises:
+            TypeError: If tag passed is not an hamster_lib.Tag instance.
+        """
+        if not isinstance(tag, lib_objects.Tag):
+            message = _("You need to pass a hamster tag")
+            raise TypeError(message)
+
+        self._interface.Remove(tag.pk)
+        return None
+
+    def get(self, pk):
+        """
+        Get an ``Tag`` by its primary key.
+
+        Args:
+            pk (int): Primary key of the ``Tag`` to be fetched.
+
+        Returns:
+            hamster_lib.Tag: ``Tag`` with given primary key.
+        """
+        result = self._interface.Get(int(pk))
+        return helpers.dbus_to_hamster_tag(result)
+
+    def get_by_name(self, name):
+        """
+        Look up a tag by its name.
+
+        Args:
+            name (text_type): Unique name of the ``Tag`` to we want to fetch.
+
+        Returns:
+            hamster_lib.Tag: ``Tag`` with given name.
+        """
+        result = self._interface.GetByName(name)
+        return helpers.dbus_to_hamster_tag(result)
+
+    def get_all(self):
+        """
+        Return a list of all tags.
+
+        Returns:
+            list: List of ``Tags``, ordered by ``lower(name)``.
+        """
+        result = self._interface.GetAll()
+        return [helpers.dbus_to_hamster_tag(tag) for tag in result]
+
+
+@python_2_unicode_compatible
+class FactManager(object):
+    """Class to handle facts."""
+
+    def __init__(self, bus):
+        """
+        Instantiate class.
+
+        Args:
+            bus (dbus.bus.BusConnection): Connection to query against.
+        """
+        bus_name = 'org.projecthamster.HamsterDBus'
+        object_path = '/org/projecthamster/HamsterDBus/FactManager'
+        interface_name = 'org.projecthamster.HamsterDBus.FactManager1'
+        dbus_object = bus.get_object(bus_name, object_path)
+        self._interface = dbus.Interface(dbus_object, interface_name)
+
+    def save(self, fact):
+        """
+        Save a Fact.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+        """
+        if not isinstance(fact, lib_objects.Fact):
+            message = _("You need to pass a ``hamster_lib.objects.Fact`` instance")
+            raise TypeError(message)
+
+        dbus_fact = helpers.hamster_to_dbus_fact(fact)
+        result = self._interface.Save(dbus_fact)
+        return helpers.dbus_to_hamster_fact(result)
+
+    def remove(self, fact):
+        """
+        Remove a Fact.
+
+        For details see the corresponding method in ``hamster_lib.storage``.
+        """
+        if not isinstance(fact, lib_objects.Fact):
+            message = _("You need to pass a ``hamster_lib.objects.Fact`` instance")
+            raise TypeError(message)
+
+        self._interface.Remove(fact.pk)
+
+    def get(self, pk):
+        """
+        Return a ``Fact`` by its primary key.
+
+        Args:
+            pk (int): Primary key of the ``Fact to be retrieved``.
+
+        Returns:
+            hamster_lib.Fact: The ``Fact`` corresponding to the primary key.
+        """
+        result = self._interface.Get(int(pk))
+        return helpers.dbus_to_hamster_fact(result)
+
+    def get_all(self, start=None, end=None, filter_term=''):
+        """
+        Return all facts within a given timeframe.
+
+        The 'timeframe' begins at the begining of ``start`` and
+        concludes at the end of ``end``.
+
+        Args:
+            start (datetime.datetime, datetime.date, datetime.time or None, optional): Consider
+                only Facts starting at or after this date. Alternatively you can
+                also pass a ``datetime.datetime`` object in which case its own
+                time will be considered instead of the default ``day_start``
+                or a ``datetime.time`` which will be considered as today.
+                Defaults to ``None``.
+            end (datetime.datetime, datetime.date, datetime.time or None, optional): Consider
+                only Facts ending before or at this date. Alternatively you can
+                also pass a ``datetime.datetime`` object in which case its own
+                time will be considered instead of the default ``day_start``
+                or a ``datetime.time`` which will be considered as today.
+                Defaults to ``None``.
+            filter_term (str, optional): Only consider ``Facts`` with this
+                string as part of their associated ``Activity.name``
+
+        Returns:
+            list: List of ``Fact``s matching given specifications.
+
+        Raises:
+            TypeError: If ``start`` or ``end`` are not ``datetime.date``, ``datetime.time`` or
+                ``datetime.datetime`` objects.
+            ValueError: If ``end`` is before ``start``.
+
+        Note:
+            * This public function only provides some sanity checks and normalization. The actual
+                backend query is handled by ``_get_all``.
+            * ``search_term`` should be prefixable with ``not`` in order to invert matching.
+            * This does only return proper facts and does not include any existing 'ongoing fact'.
+        """
+        if not (isinstance(start, datetime.datetime) or isinstance(start, datetime.date) or (
+                isinstance(start, datetime.time) or (start is None))):
+            raise TypeError
+        if not (isinstance(end, datetime.datetime) or isinstance(end, datetime.date) or (
+                isinstance(end, datetime.time) or (end is None))):
+            raise TypeError
+
+        if start and end and (end <= start):
+            message = _("End value can not be earlier than start!")
+            raise ValueError(message)
+
+        start = helpers.datetime_to_text(start)
+        end = helpers.datetime_to_text(end)
+        filter_term = text_type(filter_term)
+        result = self._interface.GetAll(start, end, filter_term)
+        return [helpers.dbus_to_hamster_fact(fact) for fact in result]
+
+    def get_today(self):
+        """
+        Return all facts for today, while respecting ``day_start``.
+
+        Returns:
+            list: List of ``Fact`` instances.
+
+        Note:
+            * This does only return proper facts and does not include any existing 'ongoing fact'.
+        """
+        result = self._interface.GetToday()
+        return [helpers.dbus_to_hamster_fact(fact) for fact in result]
+
+    def stop_tmp_fact(self):
+        """
+        Stop current 'ongoing fact'.
+
+        Returns:
+            hamster_lib.Fact: The stored fact.
+
+        Raises:
+            ValueError: If there is no currently 'ongoing fact' present.
+        """
+        result = self._interface.StopTmpFact()
+        return helpers.dbus_to_hamster_fact(result)
+
+    def cancel_tmp_fact(self):
+        """
+        Provide a way to stop an 'ongoing fact' without saving it in the backend.
+
+        Returns:
+            None: If everything worked as expected.
+
+        Raises:
+            KeyError: If no ongoing fact is present.
+        """
+        self._interface.CancelTmpFact()
+        return None
+
+    def get_tmp_fact(self):
+        """
+        Provide a way to retrieve any existing 'ongoing fact'.
+
+        Returns:
+            hamster_lib.Fact: An instance representing our current 'ongoing fact'.capitalize
+
+        Raises:
+            KeyError: If no ongoing fact is present.
+        """
+        result = self._interface.GetTmpFact()
+        return helpers.dbus_to_hamster_fact(result)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,6 +17,16 @@ class CategoryFactory(factory.Factory):
         model = hamster_lib.Category
 
 
+class TagFactory(factory.Factory):
+    """Provide a factory for randomized ``hamster_lib.Tag`` instances."""
+
+    pk = None
+    name = fauxfactory.gen_utf8()
+
+    class Meta:
+        model = hamster_lib.Tag
+
+
 class ActivityFactory(factory.Factory):
     """Provide a factory for randomized ``hamster_lib.Activity`` instances."""
 

--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -1,0 +1,26 @@
+"""
+Unittests for the dbus-storage backend.
+
+At first glance it may seem strange that we add mocked service methods not as
+part of the test setup but in each individual test. This is due to
+``dbus-python``s strange way to handle mocking return values. Whilst all tests
+related to a particular test class deal with the same method, they may expect
+different return values specific to their test goals. As ``AddMethod`` does not
+really seem to allow for dynamic return values it seems cleaner and more
+transparent to provide them with each individual test explicitly.
+
+Please not that the unit tests included here do *mock* the underlying dbus
+service.  This mean in particular that they make assumptions about the services
+signature.  As a consequence those tests will not be able to make sure that the
+tested storage backend will actually work against a given service implementation
+(such as provided by ``hamster_dbus.objects``). For this to be tested, dedicated
+integration tests are needed.
+
+Most manager methods really only call the relevant de/serialization functions
+before/after the respective dbus object method call. As the method call itself
+is mocked, and the de/serialization functions are tested separately there is
+relatively little to test here for now and we mainly make sure that the returned
+types match our expectation. Still, even those basic test coverage will provide
+useful guards against regression bugs as they ensure the relevant manager
+methods are called at least once.
+"""

--- a/tests/storage/common.py
+++ b/tests/storage/common.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+"""Module to provide a common base ``TestCase``."""
+
+
+from __future__ import absolute_import, unicode_literals
+
+import dbusmock
+
+
+class HamsterDBusManagerTestCase(dbusmock.DBusTestCase):
+    """
+    Common testcase for storage backend unittests.
+
+    This test case makes sure tests are run against a new private session bus
+    instance and provides easy access to the underlying dbus connection.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup new private session bus."""
+        cls.start_session_bus()
+        cls.dbus_con = cls.get_dbus()
+
+    def tearDown(self):
+        """Terminate any service launched by the test case."""
+        self.service_mock.terminate()
+        self.service_mock.wait()

--- a/tests/storage/test_activity_manager.py
+++ b/tests/storage/test_activity_manager.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unittests for ``hamster_dbus.storage.ActivityManager``.
+
+Please refer to ``__init__.py`` for general details.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import subprocess
+
+import dbus
+import dbusmock
+from hamster_lib import objects as lib_objects
+
+from hamster_dbus import storage
+
+from . import common
+from .. import factories
+
+
+class BaseTestActivityManager(common.HamsterDBusManagerTestCase):
+    """Base test case that provides infrastructure common to all other test cases."""
+
+    def setUp(self):
+        """
+        Setup a mock ``ActivityManager`` object and provide a convenient interface.
+
+        By adding methods to ``self.interface`` individual tests can mock an available
+        dbus object while ``self.manager`` provides easy access to an actual
+        ``ActivityManager`` instance. By explicitly passing our test session bus
+        we make sure the manager queries against the right bus/object.
+        """
+        self.service_mock = self.spawn_server(
+            'org.projecthamster.HamsterDBus',
+            '/org/projecthamster/HamsterDBus/ActivityManager',
+            'org.projecthamster.HamsterDBus.ActivityManager1',
+            stdout=subprocess.PIPE
+        )
+
+        self.dbus_object = self.dbus_con.get_object(
+            'org.projecthamster.HamsterDBus',
+            '/org/projecthamster/HamsterDBus/ActivityManager'
+        )
+
+        self.interface = dbus.Interface(self.dbus_object, dbusmock.MOCK_IFACE)
+        self.manager = storage.ActivityManager(bus=self.dbus_con)
+
+
+class TestSave(BaseTestActivityManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestSave, self).setUp()
+        self.existing_activity = factories.ActivityFactory(pk=1)
+
+    def test_existing(self):
+        """Make sure saving an existing activity returns an ``Activity`` instance."""
+        self.dbus_object.AddMethod(
+            '', 'Save', '(is(is)b)', '(is(is)b)', 'ret = (1, "foo", (1, "bar"), False)'
+        )
+
+        result = self.manager.save(self.existing_activity)
+        self.assertIsInstance(result, lib_objects.Activity)
+
+    def test_save_non_activivty(self):
+        """Make sure that saving anything but an ``Activity`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.save('foobar')
+
+
+class TestGetOrCreate(BaseTestActivityManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestGetOrCreate, self).setUp()
+        self.new_activivty = factories.ActivityFactory(pk=None)
+        self.existing_activity = factories.ActivityFactory(pk=1)
+
+    def test_existing_activity(self):
+        """Make sure passing an existing activity returns an ``Activity`` instance."""
+        self.dbus_object.AddMethod(
+            '', 'GetOrCreate', '(is(is)b)', '(is(is)b)', 'ret = (1, "foo", (1, "bar"), False)'
+        )
+
+        result = self.manager.get_or_create(self.existing_activity)
+        self.assertIsInstance(result, lib_objects.Activity)
+
+    def test_new_activity(self):
+        """Make sure passing a new activity returns an ``Activity`` instance."""
+        self.dbus_object.AddMethod(
+            '', 'GetOrCreate', '(is(is)b)', '(is(is)b)', 'ret = (1, "foo", (1, "bar"), False)'
+        )
+
+        result = self.manager.get_or_create(self.new_activivty)
+        self.assertIsInstance(result, lib_objects.Activity)
+
+    def test_save_non_activivty(self):
+        """Make sure that saving anything but an ``Activity`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.get_or_create('string')
+
+
+class TestRemove(BaseTestActivityManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestRemove, self).setUp()
+        self.existing_activity = factories.ActivityFactory(pk=1)
+
+    def test_remove_existing(self):
+        """Make sure that removing an ``Activity`` returns ``True``."""
+        self.dbus_object.AddMethod('', 'Remove', 'i', '', '')
+
+        result = self.manager.remove(self.existing_activity)
+        self.assertTrue(result)
+
+    def test_save_non_activivty(self):
+        """Make sure that saving anything but an ``Activity`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.remove('string')
+
+
+class TestGet(BaseTestActivityManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestGet, self).setUp()
+        self.existing_activity = factories.ActivityFactory(pk=1)
+
+    def test_get_existing(self):
+        """Make sure an ``Activity`` instance is returned."""
+
+        self.dbus_object.AddMethod(
+            '', 'Get', 'i', '(is(is)b)', 'ret = (1, "foo", (1, "bar"), False)'
+        )
+
+        result = self.manager.get(self.existing_activity.pk)
+        self.assertIsInstance(result, lib_objects.Activity)
+
+
+class TestGetByComposite(BaseTestActivityManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestGetByComposite, self).setUp()
+        self.existing_activity = factories.ActivityFactory(pk=1)
+
+    def test_with_category(self):
+        """Make sure an ``Activity`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetByComposite', 's(is)', '(is(is)b)', 'ret = (1, "foo", (1, "bar"), False)'
+        )
+
+        result = self.manager.get_by_composite(
+            # [FIXME]
+            # It looks like ``python-dbusmock`` is not truely python 2
+            # compatible and uses problematic ``str``-casts.
+            # self.existing_activity.name, self.existing_activity.category
+            'fooo', self.existing_activity.category
+        )
+        self.assertIsInstance(result, lib_objects.Activity)
+
+    def test_without_category(self):
+        """Make sure an ``Activity`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetByComposite', 's(is)', '(is(is)b)', 'ret = (1, "foo", (-2, ""), False)'
+        )
+
+        # [FIXME]
+        # It looks like ``python-dbusmock`` is not truely python 2
+        # compatible and uses problematic ``str``-casts.
+        # self.existing_activity.name, self.existing_activity.category
+        result = self.manager.get_by_composite('fooo', None)
+        self.assertIsInstance(result, lib_objects.Activity)
+
+    def test_invalid_category_type(self):
+        """Make sure that anything but an ``Activity`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.get_by_composite('foo', 'category1')
+
+
+class TestGetAll(BaseTestActivityManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestGetAll, self).setUp()
+        self.existing_category = factories.CategoryFactory(pk=1)
+
+    def test_filter_by_existing_category(self):
+        """Make sure an iterator of ``Activity`` instances is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetAll', 'is', 'a(is(is)b)', 'ret = [(1, "foo", (1, "bar"), False)]'
+        )
+
+        result = self.manager.get_all(self.existing_category, 'foobar')
+        for each in result:
+            self.assertIsInstance(each, lib_objects.Activity)
+
+    def test_filter_without_category(self):
+        """Make sure an iterator of ``Activity`` instances is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetAll', 'is', 'a(is(is)b)', 'ret = [(1, "foo", (1, "bar"), False)]'
+        )
+
+        result = self.manager.get_all(None, 'foobar')
+        for each in result:
+            self.assertIsInstance(each, lib_objects.Activity)
+
+    def test_allow_all_categories(self):
+        """Make sure an iterator of ``Activity`` instances is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetAll', 'is', 'a(is(is)b)', 'ret = [(1, "foo", (1, "bar"), False)]'
+        )
+
+        result = self.manager.get_all(category=False, search_term='foo')
+        for each in result:
+            self.assertIsInstance(each, lib_objects.Activity)
+
+    def test_invalid_category(self):
+        """Make sure that anything but an ``Category`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.get_all('category', 'foo')

--- a/tests/storage/test_category_manager.py
+++ b/tests/storage/test_category_manager.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unittests for ``hamster_dbus.storage.CategoryManager``.
+
+Please refer to ``__init__.py`` for general details.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import subprocess
+
+import dbus
+import dbusmock
+from hamster_lib import objects as lib_objects
+
+from hamster_dbus import storage
+
+from . import common
+from .. import factories
+
+
+class BaseTestCategoryManager(common.HamsterDBusManagerTestCase):
+    """Base test case that provides infrastructure common to all other test cases."""
+
+    def setUp(self):
+        """
+        Setup a mock ``CategoryManager`` object and provide a convenient interface.
+
+        By adding methods to ``self.interface`` individual tests can mock an available
+        dbus object while ``self.manager`` provides easy access to an actual
+        ``CategoryManager`` instance. By explicitly passing our test session bus
+        we make sure the manager queries against the right bus/object.
+        """
+        self.service_mock = self.spawn_server(
+            'org.projecthamster.HamsterDBus',
+            '/org/projecthamster/HamsterDBus/CategoryManager',
+            'org.projecthamster.HamsterDBus.CategoryManager1',
+            stdout=subprocess.PIPE
+        )
+
+        self.dbus_object = self.dbus_con.get_object(
+            'org.projecthamster.HamsterDBus',
+            '/org/projecthamster/HamsterDBus/CategoryManager'
+        )
+
+        self.interface = dbus.Interface(self.dbus_object, dbusmock.MOCK_IFACE)
+        self.manager = storage.CategoryManager(bus=self.dbus_con)
+
+
+class TestSave(BaseTestCategoryManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestSave, self).setUp()
+        self.existing_category = factories.CategoryFactory(pk=1)
+
+    def test_save(self):
+        """Make sure a ``Category`` instance is returned."""
+        self.dbus_object.AddMethod('', 'Save', '(is)', '(is)', 'ret = (1, "foo")')
+
+        result = self.manager.save(self.existing_category)
+        self.assertIsInstance(result, lib_objects.Category)
+
+    def test_save_non_category(self):
+        """Make sure that passing anything but a ``Category`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.save('foobar')
+
+
+class TestGetOrCreate(BaseTestCategoryManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestGetOrCreate, self).setUp()
+        self.new_category = factories.CategoryFactory()
+        self.existing_category = factories.CategoryFactory(pk=1)
+
+    def test_get_or_create_get(self):
+        """Make sure a ``Category`` instance is returned."""
+        self.dbus_object.AddMethod('', 'GetOrCreate', '(is)', '(is)', 'ret = (1, "foo")')
+
+        result = self.manager.get_or_create(self.existing_category)
+        self.assertIsInstance(result, lib_objects.Category)
+
+    def test_get_or_create_create(self):
+        """Make sure a ``Category`` instance is returned."""
+        self.dbus_object.AddMethod('', 'GetOrCreate', '(is)', '(is)', 'ret = (1, "foo")')
+
+        result = self.manager.get_or_create(self.new_category)
+        self.assertIsInstance(result, lib_objects.Category)
+
+    def test_non_category_instance(self):
+        """Make sure that passing anything but a ``Category`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.get_or_create('foobar')
+
+
+class TestRemove(BaseTestCategoryManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestRemove, self).setUp()
+        self.existing_category = factories.CategoryFactory(pk=1)
+
+    def test_remove(self):
+        """Make sure a ``None`` is returned."""
+        self.dbus_object.AddMethod('', 'Remove', 'i', '', '')
+        result = self.manager.remove(self.existing_category)
+        self.assertIsNone(result)
+
+    def test_non_category_instance(self):
+        """Make sure that passing anything but a ``Category`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.remove(1)
+
+
+class TestGet(BaseTestCategoryManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestGet, self).setUp()
+        self.existing_category = factories.CategoryFactory(pk=1)
+
+    def test_get(self):
+        """Make sure a ``Category`` instance is returned."""
+        self.dbus_object.AddMethod('', 'Get', 'i', '(is)', 'ret = (1, "foo")')
+        result = self.manager.get(self.existing_category.pk)
+        self.assertIsInstance(result, lib_objects.Category)
+
+
+class TestGetByName(BaseTestCategoryManager):
+    def test_get_by_name(self):
+        """Make sure a ``Category`` instance is returned."""
+        self.dbus_object.AddMethod('', 'GetByName', 's', '(is)', 'ret = (1, "foo")')
+        # [FIXME]
+        # Due to problems with dbusmock under python 2
+        result = self.manager.get_by_name('foobar')
+        self.assertIsInstance(result, lib_objects.Category)
+
+
+class TestGetAll(BaseTestCategoryManager):
+    def test_get_all(self):
+        """Make sure an iterator of ``Category`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', '', 'a(is)', 'ret = [(1, "foo"), (2, "bar")]')
+        result = self.manager.get_all()
+        for each in result:
+            self.assertIsInstance(each, lib_objects.Category)

--- a/tests/storage/test_dbus_store.py
+++ b/tests/storage/test_dbus_store.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unittests for DBusStore.
+
+Please refer to ``__init__.py`` for general details.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import subprocess
+
+from hamster_dbus import storage
+
+from . import common
+
+
+class TestDBusStore(common.HamsterDBusManagerTestCase):
+
+    def setUp(self):
+        """Setup test environment."""
+        # We have to launch a mocked service in order to provide the
+        # 'org.projecthamster.HamsterDBus' namespace.
+        # Which object and interface does not actually matter for this test.
+        self.service_mock = self.spawn_server(
+            'org.projecthamster.HamsterDBus',
+            '/org/projecthamster/HamsterDBus/FactManager',
+            'org.projecthamster.HamsterDBus.FactManager1',
+            stdout=subprocess.PIPE
+        )
+
+        # For our test purpose, an empty config test suffices.
+        self.store = storage.DBusStore({})
+
+    def test_categories_manager(self):
+        """Make sure a ``storage.CategoryManager`` is instantiated."""
+        self.assertIsInstance(self.store.categories, storage.CategoryManager)
+
+    def test_activities_manager(self):
+        """Make sure a ``storage.ActivityManager`` is instantiated."""
+        self.assertIsInstance(self.store.activities, storage.ActivityManager)
+
+    def test_tags_manager(self):
+        """Make sure a ``storage.TagManager`` is instantiated."""
+        self.assertIsInstance(self.store.tags, storage.TagManager)
+
+    def test_facts_manager(self):
+        """Make sure a ``storage.FactManager`` is instantiated."""
+        self.assertIsInstance(self.store.facts, storage.FactManager)
+
+    def test_cleanup(self):
+        """Test the cleanup method."""
+        self.assertIsNone(self.store.cleanup())
+
+    def test_explicit_bus(self):
+        """Make sure that an explicitly passed bus is really used."""
+        self.store = storage.DBusStore({}, bus=self.dbus_con)
+        self.assertEqual(self.store._bus, self.dbus_con)

--- a/tests/storage/test_fact_manager.py
+++ b/tests/storage/test_fact_manager.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unittests for ``hamster_dbus.storage.FactManager``.
+
+Please refer to ``__init__.py`` for general details.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+import subprocess
+
+import dbus
+import dbusmock
+from hamster_lib import objects as lib_objects
+
+from hamster_dbus import storage
+
+from . import common
+from .. import factories
+
+
+class BaseTestFactManager(common.HamsterDBusManagerTestCase):
+    """Base test case that provides infrastructure common to all other test cases."""
+
+    def setUp(self):
+        """
+        Setup a mock ``FactManager`` object and provide a convenient interface.
+
+        By adding methods to ``self.interface`` individual tests can mock an available
+        dbus object while ``self.manager`` provides easy access to an actual
+        ``FactManager`` instance. By explicitly passing our test session bus
+        we make sure the manager queries against the right bus/object.
+        """
+        self.service_mock = self.spawn_server(
+            'org.projecthamster.HamsterDBus',
+            '/org/projecthamster/HamsterDBus/FactManager',
+            'org.projecthamster.HamsterDBus.FactManager1',
+            stdout=subprocess.PIPE
+        )
+
+        self.dbus_object = self.dbus_con.get_object(
+            'org.projecthamster.HamsterDBus',
+            '/org/projecthamster/HamsterDBus/FactManager'
+        )
+
+        self.interface = dbus.Interface(self.dbus_object, dbusmock.MOCK_IFACE)
+        self.manager = storage.FactManager(bus=self.dbus_con)
+
+
+class TestSave(BaseTestFactManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestSave, self).setUp()
+        self.new_fact = factories.FactFactory()
+        self.existing_fact = factories.FactFactory(pk=1)
+
+    def test_save_existing(self):
+        """Make sure a ``Fact`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'Save', '(isss(is(is)b)a(is))', '(isss(is(is)b)a(is))',
+            'ret = (1, "2016-12-01 18:00:00", "2016-12-01 19:00:00", "description",'
+            '(1, "foo", (2, "bar"), False), [(1, "tag1"), (2, "tag2")])'
+        )
+
+        result = self.manager.save(self.existing_fact)
+        self.assertIsInstance(result, lib_objects.Fact)
+
+    def test_save_new(self):
+        """Make sure a ``Fact`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'Save', '(isss(is(is)b)a(is))', '(isss(is(is)b)a(is))',
+            'ret = (1, "2016-12-01 18:00:00", "2016-12-01 19:00:00", "description",'
+            '(1, "foo", (2, "bar"), False), [(1, "tag1"), (2, "tag2")])'
+        )
+
+        result = self.manager.save(self.new_fact)
+        self.assertIsInstance(result, lib_objects.Fact)
+
+    def test_non_fact_instance(self):
+        """Make sure that passing anything but a ``Fact`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.save('foobar')
+
+
+class TestRemove(BaseTestFactManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestRemove, self).setUp()
+        self.existing_fact = factories.FactFactory(pk=1)
+
+    def test_remove(self):
+        """Make sure ``None`` is returned."""
+        self.dbus_object.AddMethod('', 'Remove', 'i', '', '')
+
+        result = self.manager.remove(self.existing_fact)
+        self.assertIsNone(result)
+
+    def test_remove_non_fact(self):
+        """Make sure that passing anything but a ``Fact`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.remove(1)
+
+
+class TestGet(BaseTestFactManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestGet, self).setUp()
+        self.existing_fact = factories.FactFactory(pk=1)
+
+    def test_get(self):
+        """Make sure a ``Fact`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'Get', 'i', '(isss(is(is)b)a(is))',
+            'ret = (1, "2016-12-01 18:00:00", "2016-12-01 19:00:00", "description",'
+            '(1, "foo", (2, "bar"), False), [(1, "tag1"), (2, "tag2")])'
+        )
+
+        result = self.manager.get(self.existing_fact.pk)
+        self.assertIsInstance(result, lib_objects.Fact)
+
+
+class TestGetAll(BaseTestFactManager):
+
+    def test_get_all(self):
+        """Make sure a iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetAll', 'sss', 'a(isss(is(is)b)a(is))',
+            'ret = [(1, "2016-12-01 18:00:00", "2016-12-01 19:00:00", "description",'
+            '(1, "foo", (2, "bar"), False), [(1, "tag1"), (2, "tag2")])]'
+        )
+
+        result = self.manager.get_all()
+        for each in result:
+            self.assertIsInstance(each, lib_objects.Fact)
+
+    def test_start_datetime(self):
+        """Make sure a iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', 'sss', 'a(isss(is(is)b)a(is))', 'ret = []')
+
+        result = self.manager.get_all(start=datetime.datetime(2017, 2, 1, 17))
+        self.assertIsInstance(result, list)
+
+    def test_start_date(self):
+        """Make sure a iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', 'sss', 'a(isss(is(is)b)a(is))', 'ret = []')
+
+        result = self.manager.get_all(start=datetime.date(2017, 2, 1))
+        self.assertIsInstance(result, list)
+
+    def test_start_time(self):
+        """Make sure a iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', 'sss', 'a(isss(is(is)b)a(is))', 'ret = []')
+
+        result = self.manager.get_all(start=datetime.time(17))
+        self.assertIsInstance(result, list)
+
+    def test_start_none(self):
+        """Make sure a iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', 'sss', 'a(isss(is(is)b)a(is))', 'ret = []')
+
+        result = self.manager.get_all(start=None)
+        self.assertIsInstance(result, list)
+
+    def test_invalid_start_type(self):
+        """Make sure that passing an invalid ``start`` argument throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.get_all(start='2012-02-01 13:30')
+
+    def test_end_datetime(self):
+        """Make sure a iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', 'sss', 'a(isss(is(is)b)a(is))', 'ret = []')
+
+        result = self.manager.get_all(end=datetime.datetime(2017, 2, 1, 17))
+        self.assertIsInstance(result, list)
+
+    def test_end_date(self):
+        """Make sure a iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', 'sss', 'a(isss(is(is)b)a(is))', 'ret = []')
+
+        result = self.manager.get_all(end=datetime.date(2017, 2, 1))
+        self.assertIsInstance(result, list)
+
+    def test_end_time(self):
+        """Make sure a iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', 'sss', 'a(isss(is(is)b)a(is))', 'ret = []')
+
+        result = self.manager.get_all(end=datetime.time(17))
+        self.assertIsInstance(result, list)
+
+    def test_end_none(self):
+        """Make sure a iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', 'sss', 'a(isss(is(is)b)a(is))', 'ret = []')
+
+        result = self.manager.get_all(end=None)
+        self.assertIsInstance(result, list)
+
+    def test_invalid_end_type(self):
+        """Make sure that passing an invalid ``end`` argument throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.get_all(end='2012-02-01 13:30')
+
+    def test_end_before_start(self):
+        """Make sure that passing an ``end<start`` throws an error."""
+        with self.assertRaises(ValueError):
+            self.manager.get_all(
+                start=datetime.datetime(2017, 2, 2, 18),
+                end=datetime.datetime(2017, 2, 1, 18)
+            )
+
+
+class TestGetToday(BaseTestFactManager):
+
+    def test_get(self):
+        """Make sure a  iterator of ``Fact`` instances is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetToday', '', 'a(isss(is(is)b)a(is))',
+            'ret = [(1, "2016-12-01 18:00:00", "2016-12-01 19:00:00", "description",'
+            '(1, "foo", (2, "bar"), False), [(1, "tag1"), (2, "tag2")])]'
+        )
+
+        result = self.manager.get_today()
+        for each in result:
+            self.assertIsInstance(each, lib_objects.Fact)
+
+
+class TestStopTmpFact(BaseTestFactManager):
+
+    def setUp(self):
+        super(TestStopTmpFact, self).setUp()
+
+    def test_stop_tmp_fact(self):
+        """Make sure a ``Fact`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'StopTmpFact', '', '(isss(is(is)b)a(is))',
+            'ret = (1, "2016-12-01 18:00:00", "2016-12-01 19:00:00", "description",'
+            '(1, "foo", (2, "bar"), False), [(1, "tag1"), (2, "tag2")])'
+        )
+
+        result = self.manager.stop_tmp_fact()
+        self.assertIsInstance(result, lib_objects.Fact)
+
+
+class TestCancelTmpFact(BaseTestFactManager):
+
+    def test_cancel_tmp_fact(self):
+        """Make sure ``None`` is returned."""
+        self.dbus_object.AddMethod(
+            '', 'CancelTmpFact', '', '', '')
+
+        result = self.manager.cancel_tmp_fact()
+        self.assertIsNone(result)
+
+
+class TestGetTmpFact(BaseTestFactManager):
+
+    def test_stop_tmp_fact(self):
+        """Make sure a ``Fact`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetTmpFact', '', '(isss(is(is)b)a(is))',
+            'ret = (1, "2016-12-01 18:00:00", "2016-12-01 19:00:00", "description",'
+            '(1, "foo", (2, "bar"), False), [(1, "tag1"), (2, "tag2")])'
+        )
+
+        result = self.manager.get_tmp_fact()
+        self.assertIsInstance(result, lib_objects.Fact)

--- a/tests/storage/test_tag_manager.py
+++ b/tests/storage/test_tag_manager.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unittests for ``hamster_dbus.storage.ActivityManager``.
+
+Please refer to ``__init__.py`` for general details.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import subprocess
+
+import dbus
+import dbusmock
+from hamster_lib import objects as lib_objects
+
+from hamster_dbus import storage
+
+from . import common
+from .. import factories
+
+
+class BaseTestTagManager(common.HamsterDBusManagerTestCase):
+    """Base test case that provides infrastructure common to all other test cases."""
+
+    def setUp(self):
+        """
+        Setup a mock ``TagyManager`` object and provide a convenient interface.
+
+        By adding methods to ``self.interface`` individual tests can mock an available
+        dbus object while ``self.manager`` provides easy access to an actual
+        ``TagManager`` instance. By explicitly passing our test session bus
+        we make sure the manager queries against the right bus/object.
+        """
+        self.service_mock = self.spawn_server(
+            'org.projecthamster.HamsterDBus',
+            '/org/projecthamster/HamsterDBus/TagManager',
+            'org.projecthamster.HamsterDBus.TagManager1',
+            stdout=subprocess.PIPE
+        )
+
+        self.dbus_object = self.dbus_con.get_object(
+            'org.projecthamster.HamsterDBus',
+            '/org/projecthamster/HamsterDBus/TagManager'
+        )
+
+        self.interface = dbus.Interface(self.dbus_object, dbusmock.MOCK_IFACE)
+        self.manager = storage.TagManager(bus=self.dbus_con)
+
+
+class TestSave(BaseTestTagManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestSave, self).setUp()
+        self.existing_tag = factories.TagFactory(pk=1)
+
+    def test_save(self):
+        """Make sure a ``Tag`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'Save', '(is)', '(is)', 'ret = (1, "foo")'
+        )
+
+        result = self.manager.save(self.existing_tag)
+        self.assertIsInstance(result, lib_objects.Tag)
+
+    def test_save_non_activivty(self):
+        """Make sure that passing anything but a ``Tag`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.save('foobar')
+
+
+class TestGetOrCreate(BaseTestTagManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestGetOrCreate, self).setUp()
+        self.new_tag = factories.TagFactory(pk=None)
+        self.existing_tag = factories.TagFactory(pk=1)
+
+    def test_get(self):
+        """Make sure a ``Tag`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetOrCreate', '(is)', '(is)', 'ret = (1, "foo")'
+        )
+        result = self.manager.get_or_create(self.existing_tag)
+        self.assertIsInstance(result, lib_objects.Tag)
+
+    def test_create(self):
+        """Make sure a ``Tag`` instance is returned."""
+        self.dbus_object.AddMethod(
+            '', 'GetOrCreate', '(is)', '(is)', 'ret = (1, "foo")'
+        )
+        result = self.manager.get_or_create(self.new_tag)
+        self.assertIsInstance(result, lib_objects.Tag)
+
+    def test_not_tag_instance(self):
+        """Make sure that passing anything but a ``Tag`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.get_or_create('foobar')
+
+
+class TestRemove(BaseTestTagManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestRemove, self).setUp()
+        self.existing_tag = factories.TagFactory(pk=1)
+
+    def test_remove(self):
+        """Make sure ``None`` is returned."""
+        self.dbus_object.AddMethod('', 'Remove', 'i', '', '')
+
+        result = self.manager.remove(self.existing_tag)
+        self.assertIsNone(result)
+
+    def test_not_tag_instance(self):
+        """Make sure that passing anything but a ``Tag`` instance throws an error."""
+        with self.assertRaises(TypeError):
+            self.manager.remove(1)
+
+
+class TestGet(BaseTestTagManager):
+
+    def setUp(self):
+        """Test setup."""
+        super(TestGet, self).setUp()
+        self.existing_tag = factories.TagFactory(pk=1)
+
+    def test_get(self):
+        """Make sure a ``Tag`` instance is returned."""
+        self.dbus_object.AddMethod('', 'Get', 'i', '(is)', 'ret = (1, "foo")')
+
+        result = self.manager.get(self.existing_tag.pk)
+        self.assertIsInstance(result, lib_objects.Tag)
+
+
+class TestGetByName(BaseTestTagManager):
+
+    def test_get_by_name(self):
+        """Make sure a ``Tag`` instance is returned."""
+        self.dbus_object.AddMethod('', 'GetByName', 's', '(is)', 'ret = (1, "foo")')
+
+        result = self.manager.get_by_name('foo')
+        self.assertIsInstance(result, lib_objects.Tag)
+
+
+class TestGetAll(BaseTestTagManager):
+
+    def test_get_all(self):
+        """Make sure a iterator of ``Tag`` instances is returned."""
+        self.dbus_object.AddMethod('', 'GetAll', '', 'a(is)', 'ret = [(1, "foo"), (2, "bar")]')
+
+        result = self.manager.get_all()
+        for each in result:
+            self.assertIsInstance(each, lib_objects.Tag)


### PR DESCRIPTION
This commit provides a working storage backend that allows clients to
connect transparently to a running hamster dbus service/objects.

Whilst this backend is mostly compliant with the API defined in
``hamster_lib.storage`` we currently do not understand enough about dbus
related Exception/Error handling to implement all Exceptions defined.
As this backend is basically just a serialization wrapper that calls the
service (which in turn then most likly uses a separate backend to
persistently store the data) we still need to find a way to pass any
errors in the server on to the client end of things.

In order to test this backend, we make heavy use of ``python-dbusmock``.
To do so we use ``UnitTest`` style tests instead of our regular py.test
test and use py.test just as a testrunner.

Closes: [DBUS-8](https://projecthamster.atlassian.net/browse/DBUS-8), [DBUS-7](https://projecthamster.atlassian.net/browse/DBUS-7)