### PR TITLE
[DBUS-16] Provide dedicated hamster service executeable

### DIFF
--- a/hamster_dbus/hamster_dbus_service.py
+++ b/hamster_dbus/hamster_dbus_service.py
@@ -20,26 +20,51 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import datetime
 import sys
 
 import hamster_lib
 from dbus.mainloop.glib import DBusGMainLoop
 from gi.repository import GLib
 
-from . import helpers, objects
+from hamster_dbus import objects
+
+
+def _get_config():
+    """
+    Get config to be passed to controller.
+
+    Attention! You need to adjust these values to you own needs! In particular
+    ``db_path`` is something you most likly do not want. If you keep it as is
+    all changes will be lost on reboot!
+    """
+    return {
+        'store': 'sqlalchemy',
+        'day_start': datetime.time(5, 30, 0),
+        'fact_min_delta': 60,
+        'tmpfile_path': '/tmp/tmpfile.pickle',
+        'db_engine': 'sqlite',
+        'db_path': ':memory:',
+    }
+
+
+def _main():
+    controller = hamster_lib.HamsterControl(_get_config())
+    DBusGMainLoop(set_as_default=True)
+    loop = GLib.MainLoop()
+    objects.HamsterDBus(loop)
+    objects.CategoryManager(controller)
+    objects.ActivityManager(controller)
+    objects.FactManager(controller)
+    # Run needs to be called after we setup our service
+    loop.run()
+
 
 if __name__ == '__main__':
     arg = ""
     if len(sys.argv) > 1:
+        # truncate args
         arg = sys.argv[1]
 
     if arg == "server":
-        controller = hamster_lib.HamsterControl(helpers.get_config())
-        DBusGMainLoop(set_as_default=True)
-        loop = GLib.MainLoop()
-        objects.HamsterDBus(loop)
-        objects.CategoryManager(controller)
-        objects.ActivityManager(controller)
-        objects.FactManager(controller)
-        # Run needs to be called after we setup our service
-        loop.run()
+        _main()

--- a/hamster_dbus/helpers.py
+++ b/hamster_dbus/helpers.py
@@ -36,18 +36,6 @@ DBusTag = namedtuple('DBusTag', ('pk', 'name'))
 DBusFact = namedtuple('DBusFact', ('pk', 'start', 'end', 'description', 'activity', 'tags'))
 
 
-def get_config():
-    """Get config to be passed to controller."""
-    return {
-        'store': 'sqlalchemy',
-        'day_start': datetime.time(5, 30, 0),
-        'fact_min_delta': 60,
-        'tmpfile_path': '/tmp/tmpfile.pickle',
-        'db_engine': 'sqlite',
-        'db_path': ':memory:',
-    }
-
-
 def _none_to_int(value):
     """
     Serialize ``None`` as an integer value.

--- a/hamster_dbus/objects.py
+++ b/hamster_dbus/objects.py
@@ -38,7 +38,7 @@ import dbus
 import dbus.service
 import hamster_lib
 
-from . import helpers
+from hamster_dbus import helpers
 
 DBUS_CATEGORIES_INTERFACE = 'org.projecthamster.HamsterDBus.CategoryManager1'
 DBUS_ACTIVITIES_INTERFACE = 'org.projecthamster.HamsterDBus.ActivityManager1'

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
                  'hamster_dbus'},
     package_data={'hamster-dbus': ['examples/*']},
     install_requires=requirements,
+    entry_points={
+        'console_scripts': ['hamster-dbus-service = hamster_dbus.hamster_dbus_service:_main']
+    },
     license="GPL3",
     zip_safe=False,
     keywords='hamster-dbus',

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,8 +5,8 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
-import dbus
 
+import dbus
 import pytest
 from hamster_lib import Activity, Category, Fact, Tag
 


### PR DESCRIPTION
This commit provides a dedicated 'dbus service' that exposes our
``hamster_dbus.objects`` managers over dbus.

This service can either be launched by executing
``./hamster_dbus_serivce.py server`` or, if the packed has been
installed into you python environment (recommended) via its
corresponding script endpoint ``hamster-dbus-service``.

Closes: [DBUS-16](https://projecthamster.atlassian.net/browse/DBUS-16)