### PR TITLE
[DBUS-15] Integration tests for service objects

### DIFF
--- a/hamster_dbus/objects.py
+++ b/hamster_dbus/objects.py
@@ -58,8 +58,6 @@ def _get_dbus_bus_name():
 class HamsterDBus(dbus.service.Object):
     """A dbus object providing access to general hamster-lib capabilities."""
 
-    # [FIXME]
-    # 'controller still needed?
     def __init__(self, loop):
         """Initialize main DBus object."""
         self._loop = loop
@@ -69,7 +67,7 @@ class HamsterDBus(dbus.service.Object):
             object_path='/org/projecthamster/HamsterDBus',
         )
 
-    @dbus.service.method('org.projecthamster.HamsterDBus')
+    @dbus.service.method('org.projecthamster.HamsterDBus1')
     def Quit(self):  # NOQA
         """Shutdown the service."""
         self._loop.quit()

--- a/hamster_dbus/objects.py
+++ b/hamster_dbus/objects.py
@@ -296,7 +296,7 @@ class FactManager(dbus.service.Object):
         return helpers.hamster_to_dbus_fact(result)
 
     @dbus.service.method(DBUS_FACTS_INTERFACE, in_signature='i')
-    def Remove(self, fact_pk):  # NOQA
+    def Remove(self, pk):  # NOQA
         """
         Remove fact from storage by it's PK.
 
@@ -306,9 +306,8 @@ class FactManager(dbus.service.Object):
         Returns:
             None: Nothing.
         """
-        fact = self._controller.store.facts.get(fact_pk)
+        fact = self._controller.store.facts.get(pk)
         self._controller.store.facts.remove(fact)
-        fact = self._controller.store.facts.get(fact_pk)
 
         # [FIXME]
         # if result:

--- a/tests/objects/__init__.py
+++ b/tests/objects/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for objects exported to dbus."""

--- a/tests/objects/conftest.py
+++ b/tests/objects/conftest.py
@@ -1,0 +1,250 @@
+"""General fixtures."""
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+import os
+import signal
+import subprocess
+import time
+
+import dbus
+import dbusmock
+import fauxfactory
+import pytest
+from pytest_factoryboy import register
+
+from hamster_dbus import helpers
+
+from .. import factories
+
+register(factories.CategoryFactory)
+register(factories.ActivityFactory)
+register(factories.FactFactory)
+
+
+@pytest.fixture
+def private_session_bus(request):
+    """
+    Launch a new 'private' session bus and return the connection instance.
+
+    This is done so that we do not 'pollute' the testing users session bus.
+
+    We can not use dbusmock classmethod as it does not return the PID, which
+    we need in order to kill the process in the finalizer.
+    """
+    def fin():
+        dbusmock.testcase.DBusTestCase.stop_dbus(pid)
+
+    def start_bus():
+        argv = ['dbus-launch']
+        out = subprocess.check_output(argv, universal_newlines=True)
+        variables = {}
+        for line in out.splitlines():
+            (k, v) = line.split('=', 1)
+            variables[k] = v
+        return (int(variables['DBUS_SESSION_BUS_PID']),
+                variables['DBUS_SESSION_BUS_ADDRESS'])
+
+    request.addfinalizer(fin)
+
+    pid, address = start_bus()
+    os.environ['DBUS_SESSION_BUS_ADDRESS'] = address
+    time.sleep(0.5)
+
+    dbus_con = dbus.bus.BusConnection(os.environ['DBUS_SESSION_BUS_ADDRESS'])
+    return dbus_con
+
+
+@pytest.fixture
+def live_service(request, private_session_bus):
+    """
+    Provide a running hamster service hooked into a private session bus.
+
+    Returns the 'daemon' ``Popen`` object as well as the bus connection it has
+    been launched on.
+
+    Note: The way a launched service determines the bus to connect to is by
+    inspecting ``DBUS_SESSION_BUS_ADDRESS`` ENVVAR. If this would be empty,
+    the default session bus is used.
+    """
+    def fin():
+        os.kill(daemon.pid, signal.SIGTERM)
+
+    request.addfinalizer(fin)
+
+    daemon = subprocess.Popen(['hamster_dbus/hamster_dbus_service.py', 'server'])
+    dbusmock.testcase.DBusTestCase.wait_for_bus_object(
+        'org.projecthamster.HamsterDBus',
+        '/org/projecthamster/HamsterDBus/ActivityManager',
+    )
+    bus = private_session_bus
+    return daemon, bus
+
+
+@pytest.fixture
+def hamster_dbus_interface(request, live_service):
+    """Provide a convenient object hook to our hamster-dbus service."""
+    daemon, bus = live_service
+    object_ = bus.get_object('org.projecthamster.HamsterDBus',
+        '/org/projecthamster/HamsterDBus')
+    interface = dbus.Interface(object_,
+        dbus_interface='org.projecthamster.HamsterDBus1')
+    return interface
+
+
+@pytest.fixture
+def category_manager(request, live_service):
+    """Provide a convenient object hook to our hamster-dbus service."""
+    daemon, bus = live_service
+    object_ = bus.get_object('org.projecthamster.HamsterDBus',
+        '/org/projecthamster/HamsterDBus/CategoryManager')
+    interface = dbus.Interface(object_,
+        dbus_interface='org.projecthamster.HamsterDBus.CategoryManager1')
+    return interface
+
+
+@pytest.fixture
+def activity_manager(request, live_service):
+    """Provide a convenient object hook to our hamster-dbus service."""
+    daemon, bus = live_service
+    object_ = bus.get_object('org.projecthamster.HamsterDBus',
+        '/org/projecthamster/HamsterDBus/ActivityManager')
+    interface = dbus.Interface(object_,
+        dbus_interface='org.projecthamster.HamsterDBus.ActivityManager1')
+    return interface
+
+
+@pytest.fixture
+def fact_manager(request, live_service):
+    """Provide a convenient object hook to our hamster-dbus service."""
+    daemon, bus = live_service
+    object_ = bus.get_object('org.projecthamster.HamsterDBus',
+        '/org/projecthamster/HamsterDBus/FactManager')
+    interface = dbus.Interface(object_,
+        dbus_interface='org.projecthamster.HamsterDBus.FactManager1')
+    return interface
+
+
+# Data
+@pytest.fixture(params=[
+    fauxfactory.gen_alpha(),
+    fauxfactory.gen_utf8(),
+    fauxfactory.gen_latin1(),
+    fauxfactory.gen_cjk(),
+])
+def category_name_parametrized(request):
+    """Provide a huge variety of possible ``Category.name`` strings."""
+    return request.param
+
+
+@pytest.fixture(params=[
+    fauxfactory.gen_alpha(),
+    fauxfactory.gen_utf8(),
+    fauxfactory.gen_latin1(),
+    fauxfactory.gen_cjk(),
+])
+def activity_name_parametrized(request):
+    """Provide a huge variety of possible ``Activity.name`` strings."""
+    return request.param
+
+
+# Stored instances
+@pytest.fixture
+def stored_category_factory(request, category_manager, category_factory, faker):
+    """
+    A factory for category instances that are present in our persistent store.
+
+    Because we do not have access to the actual store we need to assume that
+    the ``Save`` method works as expected.
+    """
+    def factory(**kwargs):
+        category = category_factory.build(**kwargs)
+        result = category_manager.Save(helpers.hamster_to_dbus_category(category))
+        return helpers.dbus_to_hamster_category(result)
+    return factory
+
+
+@pytest.fixture
+def stored_category(request, stored_category_factory):
+    """A singe persistent category instances."""
+    return stored_category_factory()
+
+
+@pytest.fixture
+def stored_category_batch_factory(request, stored_category_factory, faker):
+    """A factory for category instances that are present in our persistent store."""
+    def factory(amount):
+        categories = []
+        for i in range(amount):
+            categories.append(stored_category_factory(name=faker.word()))
+        return categories
+    return factory
+
+
+@pytest.fixture
+def stored_activity_factory(request, activity_manager, activity_factory, faker):
+    """
+    A factory for activity instances that are present in our persistent store.
+
+    Because we do not have access to the actual store we need to assume that
+    the ``Save`` method works as expected.
+    """
+    def factory(**kwargs):
+        activity = activity_factory.build(**kwargs)
+        result = activity_manager.Save(helpers.hamster_to_dbus_activity(activity))
+        return helpers.dbus_to_hamster_activity(result)
+    return factory
+
+
+@pytest.fixture
+def stored_activity(request, stored_activity_factory):
+    """A singe persistent activity instances."""
+    return stored_activity_factory()
+
+
+@pytest.fixture
+def stored_activity_batch_factory(request, stored_activity_factory, faker):
+    """Factory for batch creating persistent activity instances."""
+    def factory(amount):
+        activities = []
+        for i in range(amount):
+            activities.append(stored_activity_factory(name=faker.word()))
+        return activities
+    return factory
+
+
+@pytest.fixture
+def stored_fact_factory(request, fact_manager, fact_factory, faker):
+    """A factory for fact instances that are present in our persistent store."""
+    def factory(**kwargs):
+        fact = fact_factory.build(**kwargs)
+        result = fact_manager.Save(helpers.hamster_to_dbus_fact(fact))
+        return helpers.dbus_to_hamster_fact(result)
+    return factory
+
+
+@pytest.fixture
+def stored_fact(request, stored_fact_factory):
+    """A singe persistent fact instances."""
+    return stored_fact_factory()
+
+
+@pytest.fixture
+def stored_fact_batch_factory(request, stored_fact_factory, faker):
+    """
+    Factory for batch creating persistent fact instances.
+
+    Because we do not have access to the actual store we need to assume that
+    the ``Save`` method works as expected.
+    """
+    def factory(amount):
+        facts = []
+        old_start = datetime.datetime.now()
+        offset = datetime.timedelta(hours=4)
+        for i in range(amount):
+            start = old_start + offset
+            fact = stored_fact_factory(start=start)
+            facts.append(fact)
+            old_start = start
+        return facts
+    return factory

--- a/tests/objects/test_objects.py
+++ b/tests/objects/test_objects.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+
+"""Integration tests for hamster_dbus.objects."""
+
+import pytest
+
+import hamster_dbus.helpers as helpers
+
+
+@pytest.mark.needs_dbus_service
+class TestCategoryManager(object):
+
+    def test_save_new(self, category_manager, category, category_name_parametrized):
+        """Make sure an instance is created and returned."""
+
+        category.name = category_name_parametrized
+        dbus_category = helpers.hamster_to_dbus_category(category)
+        result = category_manager.Save(dbus_category)
+        result = helpers.dbus_to_hamster_category(result)
+        assert result.pk
+        assert category.as_tuple(include_pk=False) == result.as_tuple(include_pk=False)
+
+    def test_remove(self, category_manager, stored_category):
+        """Make sure a category is removed."""
+        result = category_manager.Remove(stored_category.pk)
+        assert result is None
+        # [FIXME]
+        # with pytest.raises(KeyError):
+        #    store.categories.get(stored_category.pk)
+
+    def test_get_by_name(self, category_manager, stored_category):
+        """Make sure a matching category is returned."""
+        result = category_manager.GetByName(stored_category.name)
+        result = helpers.dbus_to_hamster_category(result)
+        assert result.pk == stored_category.pk
+        assert result.name == stored_category.name
+
+    def test_get_all(self, category_manager, stored_category_batch_factory):
+        """Make sure we get all stored categories."""
+        categories = stored_category_batch_factory(5)
+        result = category_manager.GetAll()
+        result = [helpers.dbus_to_hamster_category(each) for each in result]
+        assert len(result) == 5
+        for category in categories:
+            assert category in result
+
+
+@pytest.mark.needs_dbus_service
+class TestActivityManager(object):
+
+    def test_save_new(self, activity_manager, activity):
+        """Make sure instance is saved and returned."""
+        dbus_activity = helpers.hamster_to_dbus_activity(activity)
+        result = activity_manager.Save(dbus_activity)
+        result = helpers.dbus_to_hamster_activity(result)
+        assert result.pk
+        assert result.name == activity.name
+        # We create a new instance, hence result will have a pk where the
+        # original does not.
+        assert activity.as_tuple(include_pk=False) == result.as_tuple(include_pk=False)
+
+    def test_remove(self, activity_manager, stored_activity):
+        """Make sure instance is removed."""
+        result = activity_manager.Remove(stored_activity.pk)
+        assert result is None
+        # [FIXME]
+        # with pytest.raises(KeyError):
+        #     store.activities.get(stored_activity.pk)
+
+    def test_get(self, activity_manager, stored_activity):
+        """Make sure instance is returned."""
+        result = activity_manager.Get(stored_activity.pk)
+        result = helpers.dbus_to_hamster_activity(result)
+        assert result == stored_activity
+
+    def test_get_all(self, activity_manager, stored_activity_batch_factory):
+        """Make sure we get all stored categories."""
+        activities = stored_activity_batch_factory(5)
+        result = activity_manager.GetAll(-2)
+        result = [helpers.dbus_to_hamster_activity(each) for each in result]
+        assert len(result) == 5
+        for activity in activities:
+            assert activity in result
+
+
+@pytest.mark.needs_dbus_service
+class TestFactManager(object):
+
+    def test_save_new(self, fact_manager, fact):
+        """Make sure instance is saved and returned."""
+        dbus_fact = helpers.hamster_to_dbus_fact(fact)
+        result = fact_manager.Save(dbus_fact)
+        result = helpers.dbus_to_hamster_fact(result)
+        assert fact.as_tuple(include_pk=False) == result.as_tuple(include_pk=False)
+
+    def test_remove(self, fact_manager, stored_fact):
+        """Make sure instance is removed."""
+        result = fact_manager.Remove(stored_fact.pk)
+        assert result is None
+        # [FIXME]
+        # with pytest.raises(KeyError):
+        #     store.facts.get(pk)
+
+    def test_get(self, fact_manager, stored_fact):
+        """Make sure instance is returned."""
+        result = fact_manager.Get(stored_fact.pk)
+        result = helpers.dbus_to_hamster_fact(result)
+        assert result == stored_fact
+
+    # [FIXME]
+    # This should be expanded
+    def test_get_all(self, fact_manager, stored_fact_batch_factory):
+        """Make sure we get all matching instances."""
+        stored_fact_batch_factory(5)
+        result = fact_manager.GetAll('', '', '')
+        assert len(result) == 5


### PR DESCRIPTION
This PR provides integration tests for ``hamster_dbus.objects`` exported to the users session bus.
After various alternative attempts it became clear in a conversation with Martin Pitt that proper unittests are not really vialble for dbus objects. Instead integration tests were suggested.

For details please also refer to the relevant commit messages.

Closes: [DBUS-15](https://projecthamster.atlassian.net/browse/DBUS-15)