### PR TITLE
[DBUS-17] Add Signals

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,14 @@ virtualenv (after ``make develop``)::
 
     make test
 
+Sidenote About Testing Signals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+So far we have not managed to establish a proper way of testing signals.
+In order to manually check if they are emitted as expected you may use the
+following (``dbus-monitor`` needs to be installed)::
+
+    dbus-monitor "type='signal',sender='org.projecthamster.HamsterDBus',interface='org.projecthamster.HamsterDBus1'
+
 
 Credits
 ---------

--- a/hamster_dbus/hamster_dbus_service.py
+++ b/hamster_dbus/hamster_dbus_service.py
@@ -52,11 +52,11 @@ def _main():
     controller = hamster_lib.HamsterControl(_get_config())
     DBusGMainLoop(set_as_default=True)
     loop = GLib.MainLoop()
-    objects.HamsterDBus(loop)
-    objects.CategoryManager(controller)
-    objects.ActivityManager(controller)
-    objects.TagManager(controller)
-    objects.FactManager(controller)
+    main_object = objects.HamsterDBus(loop)
+    objects.CategoryManager(controller, main_object)
+    objects.ActivityManager(controller, main_object)
+    objects.TagManager(controller, main_object)
+    objects.FactManager(controller, main_object)
     # Run needs to be called after we setup our service
     loop.run()
 

--- a/hamster_dbus/objects.py
+++ b/hamster_dbus/objects.py
@@ -114,7 +114,7 @@ class CategoryManager(dbus.service.Object):
         self._busname = _get_dbus_bus_name(bus)
 
         super(CategoryManager, self).__init__(
-            bus_name=_get_dbus_bus_name(),
+            bus_name=self._busname,
             object_path='/org/projecthamster/HamsterDBus/CategoryManager',
         )
 

--- a/hamster_dbus/objects.py
+++ b/hamster_dbus/objects.py
@@ -131,6 +131,8 @@ class CategoryManager(dbus.service.Object):
         """
         category = helpers.dbus_to_hamster_category(category_tuple)
         category = self._controller.store.categories.save(category)
+
+        self._main_object.CategoryChanged()
         return helpers.hamster_to_dbus_category(category)
 
     @dbus.service.method(DBUS_CATEGORIES_INTERFACE, in_signature='i')
@@ -149,6 +151,8 @@ class CategoryManager(dbus.service.Object):
         # retrieval.
         category = self._controller.store.categories.get(pk)
         self._controller.store.categories.remove(category)
+
+        self._main_object.CategoryChanged()
         return None
 
     @dbus.service.method(DBUS_CATEGORIES_INTERFACE, in_signature='s', out_signature='(is)')
@@ -212,6 +216,8 @@ class TagManager(dbus.service.Object):
         """
         tag = helpers.dbus_to_hamster_tag(tag_tuple)
         tag = self._controller.store.tags.save(tag)
+
+        self._main_object.TagChanged()
         return helpers.hamster_to_dbus_tag(tag)
 
     @dbus.service.method(DBUS_TAGS_INTERFACE, in_signature='i')
@@ -230,6 +236,8 @@ class TagManager(dbus.service.Object):
         # retrieval.
         tag = self._controller.store.tags.get(pk)
         self._controller.store.tags.remove(tag)
+
+        self._main_object.TagChanged()
         return None
 
     @dbus.service.method(DBUS_TAGS_INTERFACE, in_signature='s', out_signature='(is)')
@@ -297,8 +305,10 @@ class ActivityManager(dbus.service.Object):
         activity = helpers.dbus_to_hamster_activity(activity_tuple)
         result = self._controller.activities.save(activity)
 
-        # [FIXME]
-        # self.activities_changed()
+        self._main_object.ActivityChanged()
+        self._main_object.CategoryChanged()
+        # This is because during activity creation/updating a new category may
+        # be created as well.
         return helpers.hamster_to_dbus_activity(result)
 
     @dbus.service.method(DBUS_ACTIVITIES_INTERFACE, in_signature='i')
@@ -314,8 +324,7 @@ class ActivityManager(dbus.service.Object):
         activity = self._controller.activities.get(pk)
         self._controller.activities.remove(activity)
 
-        # [FIXME]
-        # self.activities_changed()
+        self._main_object.ActivityChanged()
         return None
 
     @dbus.service.method(DBUS_ACTIVITIES_INTERFACE, in_signature='i', out_signature='(is(is)b)')
@@ -400,8 +409,12 @@ class FactManager(dbus.service.Object):
         fact = hamster_lib.Fact.create_from_raw_fact(raw_fact)
         result = self._controller.store.facts.save(fact)
 
-        # [FIXME]
-        # self.facts_changed()
+        self._main_object.FactChanged()
+        self._main_object.CategoryChanged()
+        self._main_object.TagChanged()
+        self._main_object.ActivityChanged()
+        # This is because during creation/updating a new related instances
+        # may be created as well.
 
         return helpers.hamster_to_dbus_fact(result)
 
@@ -421,8 +434,12 @@ class FactManager(dbus.service.Object):
         fact = helpers.dbus_to_hamster_fact(fact_tuple)
         result = self._controller.store.facts.save(fact)
 
-        # [FIXME]
-        # self.facts_changed()
+        self._main_object.FactChanged()
+        self._main_object.CategoryChanged()
+        self._main_object.TagChanged()
+        self._main_object.ActivityChanged()
+        # This is because during creation/updating a new related instances
+        # may be created as well.
 
         return helpers.hamster_to_dbus_fact(result)
 
@@ -440,9 +457,7 @@ class FactManager(dbus.service.Object):
         fact = self._controller.store.facts.get(pk)
         self._controller.store.facts.remove(fact)
 
-        # [FIXME]
-        # if result:
-        #    self.facts_changed()
+        self._main_object.FactChanged()
         return None
 
     @dbus.service.method(DBUS_FACTS_INTERFACE, in_signature='i',

--- a/hamster_dbus/objects.py
+++ b/hamster_dbus/objects.py
@@ -99,9 +99,18 @@ class HamsterDBus(dbus.service.Object):
 class CategoryManager(dbus.service.Object):
     """CategoryManager object to be exposed via DBus."""
 
-    def __init__(self, controller, bus=None):
-        """Initialize category manager object."""
+    def __init__(self, controller, main_object, bus=None):
+        """
+        Initialize category manager object.
+
+        Args:
+            controller: FIXME
+            main_object: ``HamsterDBus`` object. This is needed in order to
+                emmit signals.
+            bus (optional): FIXME
+        """
         self._controller = controller
+        self._main_object = main_object
         self._busname = _get_dbus_bus_name(bus)
 
         super(CategoryManager, self).__init__(
@@ -171,9 +180,18 @@ class CategoryManager(dbus.service.Object):
 class TagManager(dbus.service.Object):
     """TagManager object to be exposed via DBus."""
 
-    def __init__(self, controller, bus=None):
-        """Initialize tag manager object."""
+    def __init__(self, controller, main_object, bus=None):
+        """
+        Initialize tag manager object.
+
+        Args:
+            controler: FIXME
+            main_object: ``HamsterDBus`` object. This is needed in order to
+                emmit signals.
+            bus (optional): FIXME
+        """
         self._controller = controller
+        self._main_object = main_object
         self._busname = _get_dbus_bus_name(bus)
 
         super(TagManager, self).__init__(
@@ -244,9 +262,20 @@ class TagManager(dbus.service.Object):
 class ActivityManager(dbus.service.Object):
     """ActivityManager object to be exposed via DBus."""
 
-    def __init__(self, controller):
-        """Initialize activity manager object."""
+    def __init__(self, controller, main_object):
+        """
+        Initialize activity manager object.
+
+        Args:
+            controler: FIXME
+            main_object: ``HamsterDBus`` object. This is needed in order to
+                emmit signals.
+        """
+        # [FIXME]
+        # Unlike with ``CategoryManager`` and ``TagManager`` we do not allow for
+        # a custom bus.
         self._controller = controller
+        self._main_object = main_object
 
         super(ActivityManager, self).__init__(
             bus_name=_get_dbus_bus_name(),
@@ -332,9 +361,20 @@ class ActivityManager(dbus.service.Object):
 class FactManager(dbus.service.Object):
     """FactManager object to be exposed via DBus."""
 
-    def __init__(self, controller):
-        """Initialize fact manager object."""
+    def __init__(self, controller, main_object):
+        """
+        Initialize fact manager object.
+
+        Args:
+            controler: FIXME
+            main_object: ``HamsterDBus`` object. This is needed in order to
+                emmit signals.
+        """
+        # [FIXME]
+        # Unlike with ``CategoryManager`` and ``TagManager`` we do not allow for
+        # a custom bus.
         self._controller = controller
+        self._main_object = main_object
 
         super(FactManager, self).__init__(
             bus_name=_get_dbus_bus_name(),

--- a/hamster_dbus/objects.py
+++ b/hamster_dbus/objects.py
@@ -70,6 +70,26 @@ class HamsterDBus(dbus.service.Object):
             object_path='/org/projecthamster/HamsterDBus',
         )
 
+    @dbus.service.signal('org.projecthamster.HamsterDBus1')
+    def CategoryChanged(self):  # NOQA
+        """Signal indicating that at least one category may have been modified."""
+        pass
+
+    @dbus.service.signal('org.projecthamster.HamsterDBus1')
+    def ActivityChanged(self):  # NOQA
+        """Signal indicating that at least one activity may have been modified."""
+        pass
+
+    @dbus.service.signal('org.projecthamster.HamsterDBus1')
+    def TagChanged(self):  # NOQA
+        """Signal indicating that at least one tag may have been modified."""
+        pass
+
+    @dbus.service.signal('org.projecthamster.HamsterDBus1')
+    def FactChanged(self):  # NOQA
+        """Signal indicating that at least one fact may have been modified."""
+        pass
+
     @dbus.service.method('org.projecthamster.HamsterDBus1')
     def Quit(self):  # NOQA
         """Shutdown the service."""

--- a/hamster_dbus/objects.py
+++ b/hamster_dbus/objects.py
@@ -109,10 +109,6 @@ class CategoryManager(dbus.service.Object):
             object_path='/org/projecthamster/HamsterDBus/CategoryManager',
         )
 
-    # [FIXME]
-    # Missing ``hamster_lib.CategoryManager`` methods that still need to be implemented:
-    # ``get_or_create``.
-
     @dbus.service.method(DBUS_CATEGORIES_INTERFACE, in_signature='(is)', out_signature='(is)')
     def Save(self, category_tuple):  # NOQA
         """


### PR DESCRIPTION
This adds basic signalling upon underlying data changes to the dbus service. Right now all signals are emitted by the ``HamsterDBus`` object. At some later time this is most likely to change to a solution where each manager emits its own corresponding signal.
Please note that we are over zealous when emitting signals as such that we emit the signal whenever an (related) instance may have changed. It will require additional changes to ``hamster-lib`` before we can have a more specific solution within our current framework. 

[Closes DBUS-17](https://projecthamster.atlassian.net/browse/DBUS-17)