### PR TITLE
Add missing double quote

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ So far we have not managed to establish a proper way of testing signals.
 In order to manually check if they are emitted as expected you may use the
 following (``dbus-monitor`` needs to be installed)::
 
-    dbus-monitor "type='signal',sender='org.projecthamster.HamsterDBus',interface='org.projecthamster.HamsterDBus1'
+    dbus-monitor "type='signal',sender='org.projecthamster.HamsterDBus',interface='org.projecthamster.HamsterDBus1'"
 
 
 Credits


### PR DESCRIPTION
Closing double quote was missing from readme file.